### PR TITLE
BaSP-TG-74: Admin Update Form

### DIFF
--- a/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
+++ b/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
-import styles from './adminForm.module.css';
-import Input from '../../../Shared/Field/Input';
-import RadioButton from '../../../Shared/Field/RadioButton';
-import Button from '../../../Shared/Buttons/Buttons';
+import styles from 'Components/SuperAdmin/Admins/Form/adminForm.module.css';
+import Input from 'Components/Shared/Field/Input';
+import RadioButton from 'Components/Shared/Field/RadioButton';
+import Button from 'Components/Shared/Buttons/Buttons';
 import { useDispatch } from 'react-redux/es/exports';
-import { addAdmin, editAdmin } from '../../../../redux/admins/thunks';
+import { addAdmin, editAdmin } from 'redux/admins/thunks';
 
 const AdminForm = ({
   showForm,

--- a/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
+++ b/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
@@ -13,7 +13,7 @@ const adminSchema = Joi.object({
   firstName: Joi.string().min(3).max(15).required(),
   lastName: Joi.string().min(3).max(15).required(),
   phone: Joi.number().min(1000000000).required().messages({
-    'number.min': 'Phone number be 10 digits long'
+    'number.min': 'Phone number must be 10 digits long'
   }),
   email: Joi.string()
     .email({ tlds: { allow: false } })

--- a/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
+++ b/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
@@ -1,11 +1,22 @@
-import React, { useState } from 'react';
-import styles from 'Components/SuperAdmin/Admins/Form/adminForm.module.css';
+import React from 'react';
+import styles from './adminForm.module.css';
 import Input from 'Components/Shared/Field/Input';
 import RadioButton from 'Components/Shared/Field/RadioButton';
 import Button from 'Components/Shared/Buttons/Buttons';
 import { useDispatch } from 'react-redux/es/exports';
 import { addAdmin, editAdmin } from 'redux/admins/thunks';
+import { joiResolver } from '@hookform/resolvers/joi';
+import Joi from 'joi';
+import { useForm } from 'react-hook-form';
 
+const adminSchema = Joi.object({
+  firstName: Joi.string().min(3).max(15).required(),
+  lastName: Joi.string().min(3).max(15).required(),
+  phone: Joi.number().min(10).required(),
+  email: Joi.string().email().required(),
+  password: Joi.string().alphanum().min(8).required(),
+  active: Joi.boolean().required()
+});
 const AdminForm = ({
   showForm,
   setShowForm,
@@ -20,7 +31,14 @@ const AdminForm = ({
 
   const dispatch = useDispatch();
 
-  const [userInput, setUserInput] = useState(previousAdmin);
+  const {
+    handleSubmit,
+    register,
+    formState: { errors }
+  } = useForm({
+    mode: 'onChange',
+    resolver: joiResolver(adminSchema)
+  });
 
   const cleanFields = () => {
     setPreviousAdmin({
@@ -34,15 +52,11 @@ const AdminForm = ({
     });
   };
 
-  const onChange = (e) => {
-    setUserInput({ ...userInput, [e.target.name]: e.target.value });
-  };
-
   const onSubmit = async (e) => {
     e.preventDefault();
 
-    if (!userInput._id) {
-      const adminResponse = await dispatch(addAdmin(userInput));
+    if (!previousAdmin._id) {
+      const adminResponse = await dispatch(addAdmin(previousAdmin));
       if (adminResponse.error) {
         setChildrenModal(adminResponse.message);
         setShowModal(true);
@@ -50,7 +64,7 @@ const AdminForm = ({
         closeForm();
       }
     } else {
-      const adminResponse = await dispatch(editAdmin(userInput));
+      const adminResponse = await dispatch(editAdmin(previousAdmin));
       if (adminResponse.error) {
         setChildrenModal(adminResponse.message);
         setShowModal(true);
@@ -67,58 +81,52 @@ const AdminForm = ({
 
   return (
     <div className={styles.container}>
-      <form onSubmit={onSubmit}>
-        <h2>Add new admin</h2>
-        <div>
-          <Input
-            type="text"
-            name="firstName"
-            label={'First name'}
-            value={userInput.firstName}
-            onChange={onChange}
-          />
-        </div>
-        <div>
-          <Input
-            type="text"
-            name="lastName"
-            label={'Last name'}
-            value={userInput.lastName}
-            onChange={onChange}
-          />
-        </div>
-        <div>
-          <Input
-            type="text"
-            name="phone"
-            label={'Phone'}
-            value={userInput.phone}
-            onChange={onChange}
-          />
-        </div>
-        <div>
-          <Input
-            type="email"
-            name="email"
-            label={'Email'}
-            value={userInput.email}
-            onChange={onChange}
-          />
-        </div>
-        <div>
-          <Input
-            type="password"
-            name="password"
-            label={'Password'}
-            value={userInput.password}
-            onChange={onChange}
-          />
-        </div>
-        <div>
-          <RadioButton name="active" label={'Active'} value={[true, false]} onChange={onChange} />
-        </div>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        {!previousAdmin._id ? <h2>Add a new admin</h2> : <h2>Edit admin</h2>}
+        <Input
+          type={'text'}
+          name={'firstName'}
+          label={'First name'}
+          register={register}
+          error={errors.firstName?.message}
+        />
+        <Input
+          type={'text'}
+          name={'lastName'}
+          label={'Last Name'}
+          register={register}
+          error={errors.lastName?.message}
+        />
+        <Input
+          type={'text'}
+          name={'phone'}
+          label={'Phone'}
+          register={register}
+          error={errors.phone?.message}
+        />
+        <Input
+          type={'email'}
+          name={'email'}
+          label={'Email'}
+          register={register}
+          error={errors.email?.message}
+        />
+        <Input
+          type={'password'}
+          name={'password'}
+          label={'Password'}
+          register={register}
+          error={errors.password?.message}
+        />
+        <RadioButton
+          name="active"
+          label={'Active'}
+          valueOptions={[true, false]}
+          register={register}
+          error={errors.active?.message}
+        />
         <div className={styles.button}>
-          <Button onClick={(e) => onSubmit(e)}>Submit</Button>
+          <Button onClick={handleSubmit(onSubmit)}>Submit</Button>
           <Button onClick={closeForm}>Close</Button>
         </div>
       </form>

--- a/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
+++ b/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
@@ -12,8 +12,9 @@ import { useForm } from 'react-hook-form';
 const adminSchema = Joi.object({
   firstName: Joi.string().min(3).max(15).required(),
   lastName: Joi.string().min(3).max(15).required(),
-  phone: Joi.number().min(1000000000).required().messages({
-    'number.min': 'Phone number must be 10 digits long'
+  phone: Joi.number().min(1000000000).max(9999999999).required().messages({
+    'number.min': 'Phone number must be 10 digits long',
+    'number.max': 'Phone number must be no more than 10 digits long'
   }),
   email: Joi.string()
     .email({ tlds: { allow: false } })

--- a/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
+++ b/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styles from './adminForm.module.css';
+import styles from 'Components/SuperAdmin/Admins/Form/adminForm.module.css';
 import Input from 'Components/Shared/Field/Input';
 import RadioButton from 'Components/Shared/Field/RadioButton';
 import Button from 'Components/Shared/Buttons/Buttons';
@@ -148,12 +148,12 @@ const AdminForm = ({
           register={register}
           error={errors.active?.message}
         />
-        <div className={styles.button}>
-          <Button onClick={handleSubmit(onSubmit)}>Submit</Button>
-          <Button onClick={() => reset()}>Reset Form</Button>
-          <Button onClick={closeForm}>Close</Button>
-        </div>
       </form>
+      <div className={styles.button}>
+        <Button onClick={handleSubmit(onSubmit)}>Submit</Button>
+        <Button onClick={() => reset()}>Reset Form</Button>
+        <Button onClick={closeForm}>Close</Button>
+      </div>
     </div>
   );
 };

--- a/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
+++ b/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
@@ -81,6 +81,8 @@ const AdminForm = ({
         setShowModal(true);
       } else {
         closeForm();
+        setChildrenModal('Admin added');
+        setShowModal(true);
       }
     } else {
       const adminResponse = await dispatch(editAdmin(data, previousAdmin._id));
@@ -89,6 +91,8 @@ const AdminForm = ({
         setShowModal(true);
       } else {
         closeForm();
+        setChildrenModal('Admin edited');
+        setShowModal(true);
       }
     }
   };

--- a/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
+++ b/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
@@ -12,7 +12,9 @@ import { useForm } from 'react-hook-form';
 const adminSchema = Joi.object({
   firstName: Joi.string().min(3).max(15).required(),
   lastName: Joi.string().min(3).max(15).required(),
-  phone: Joi.number().min(1000000000).required(),
+  phone: Joi.number().min(1000000000).required().messages({
+    'number.min': 'Phone number be 10 digits long'
+  }),
   email: Joi.string()
     .email({ tlds: { allow: false } })
     .required(),
@@ -142,12 +144,12 @@ const AdminForm = ({
           register={register}
           error={errors.active?.message}
         />
+        <div className={styles.button}>
+          <Button onClick={handleSubmit(onSubmit)}>Submit</Button>
+          <Button onClick={() => reset()}>Reset Form</Button>
+          <Button onClick={closeForm}>Close</Button>
+        </div>
       </form>
-      <div className={styles.button}>
-        <Button onClick={handleSubmit(onSubmit)}>Submit</Button>
-        <Button onClick={() => reset()}>Reset Form</Button>
-        <Button onClick={closeForm}>Close</Button>
-      </div>
     </div>
   );
 };

--- a/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
+++ b/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
@@ -41,6 +41,7 @@ const AdminForm = ({
   const {
     handleSubmit,
     register,
+    reset,
     formState: { errors }
   } = useForm({
     mode: 'onChange',
@@ -67,9 +68,9 @@ const AdminForm = ({
     });
   };
 
-  const onSubmit = async (previousAdmin) => {
+  const onSubmit = async (data) => {
     if (!previousAdmin._id) {
-      const adminResponse = await dispatch(addAdmin(previousAdmin));
+      const adminResponse = await dispatch(addAdmin(data));
       if (adminResponse.error) {
         setChildrenModal(adminResponse.message);
         setShowModal(true);
@@ -77,7 +78,7 @@ const AdminForm = ({
         closeForm();
       }
     } else {
-      const adminResponse = await dispatch(editAdmin(previousAdmin));
+      const adminResponse = await dispatch(editAdmin(data, previousAdmin._id));
       if (adminResponse.error) {
         setChildrenModal(adminResponse.message);
         setShowModal(true);
@@ -140,6 +141,7 @@ const AdminForm = ({
         />
         <div className={styles.button}>
           <Button onClick={handleSubmit(onSubmit)}>Submit</Button>
+          <Button onClick={() => reset()}>Reset Form</Button>
           <Button onClick={closeForm}>Close</Button>
         </div>
       </form>

--- a/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
+++ b/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
@@ -12,10 +12,17 @@ import { useForm } from 'react-hook-form';
 const adminSchema = Joi.object({
   firstName: Joi.string().min(3).max(15).required(),
   lastName: Joi.string().min(3).max(15).required(),
-  phone: Joi.number().min(10).required(),
-  email: Joi.string().email().required(),
-  password: Joi.string().alphanum().min(8).required(),
-  active: Joi.boolean().required()
+  phone: Joi.string()
+    .length(10)
+    .pattern(/^[0-9]+$/)
+    .required(),
+  email: Joi.string()
+    .email({ tlds: { allow: false } })
+    .required(),
+  password: Joi.string().alphanum().min(8).max(20).required(),
+  active: Joi.boolean().required().messages({
+    'boolean.base': 'You must select an option'
+  })
 });
 const AdminForm = ({
   showForm,
@@ -37,7 +44,15 @@ const AdminForm = ({
     formState: { errors }
   } = useForm({
     mode: 'onChange',
-    resolver: joiResolver(adminSchema)
+    resolver: joiResolver(adminSchema),
+    defaultValues: {
+      firstName: previousAdmin.firstName,
+      lastName: previousAdmin.lastName,
+      phone: previousAdmin.phone,
+      email: previousAdmin.email,
+      password: previousAdmin.password,
+      active: previousAdmin.active
+    }
   });
 
   const cleanFields = () => {
@@ -52,9 +67,7 @@ const AdminForm = ({
     });
   };
 
-  const onSubmit = async (e) => {
-    e.preventDefault();
-
+  const onSubmit = async (previousAdmin) => {
     if (!previousAdmin._id) {
       const adminResponse = await dispatch(addAdmin(previousAdmin));
       if (adminResponse.error) {

--- a/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
+++ b/src/Components/SuperAdmin/Admins/Form/AdminForm.jsx
@@ -12,14 +12,17 @@ import { useForm } from 'react-hook-form';
 const adminSchema = Joi.object({
   firstName: Joi.string().min(3).max(15).required(),
   lastName: Joi.string().min(3).max(15).required(),
-  phone: Joi.string()
-    .length(10)
-    .pattern(/^[0-9]+$/)
-    .required(),
+  phone: Joi.number().min(1000000000).required(),
   email: Joi.string()
     .email({ tlds: { allow: false } })
     .required(),
-  password: Joi.string().alphanum().min(8).max(20).required(),
+  password: Joi.string()
+    .min(8)
+    .required()
+    .regex(/^(?=.*?\d)(?=.*?[a-zA-Z])[a-zA-Z\d]+$/)
+    .messages({
+      'string.pattern.base': 'Password must contain letters and numbers'
+    }),
   active: Joi.boolean().required().messages({
     'boolean.base': 'You must select an option'
   })
@@ -139,12 +142,12 @@ const AdminForm = ({
           register={register}
           error={errors.active?.message}
         />
-        <div className={styles.button}>
-          <Button onClick={handleSubmit(onSubmit)}>Submit</Button>
-          <Button onClick={() => reset()}>Reset Form</Button>
-          <Button onClick={closeForm}>Close</Button>
-        </div>
       </form>
+      <div className={styles.button}>
+        <Button onClick={handleSubmit(onSubmit)}>Submit</Button>
+        <Button onClick={() => reset()}>Reset Form</Button>
+        <Button onClick={closeForm}>Close</Button>
+      </div>
     </div>
   );
 };

--- a/src/Components/SuperAdmin/Admins/Form/adminForm.module.css
+++ b/src/Components/SuperAdmin/Admins/Form/adminForm.module.css
@@ -31,7 +31,7 @@
 
 .button {
   display: flex;
-  width: 100%;
+  width: 50%;
   justify-content: space-around;
   padding: 15px;
 }

--- a/src/Components/SuperAdmin/Admins/List/List.jsx
+++ b/src/Components/SuperAdmin/Admins/List/List.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import styles from './list.module.css';
-import Row from '../../../Shared/Row/Row';
+import styles from 'Components/SuperAdmin/Admins/List/list.module.css';
+import Row from 'Components/Shared/Row/Row';
 import { useDispatch, useSelector } from 'react-redux/es/exports';
-import { deleteAdmin } from '../../../../redux/admins/thunks';
+import { deleteAdmin } from 'redux/admins/thunks';
 
 const List = ({ setShowForm, setPreviousAdmin }) => {
   const dispatch = useDispatch();

--- a/src/Components/SuperAdmin/Admins/List/List.jsx
+++ b/src/Components/SuperAdmin/Admins/List/List.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import styles from 'Components/SuperAdmin/Admins/List/list.module.css';
-import Row from 'Components/Shared/Row/Row';
+import Table from 'Components/Shared/Table/Table';
 import { useDispatch, useSelector } from 'react-redux/es/exports';
 import { deleteAdmin } from 'redux/admins/thunks';
 
@@ -21,32 +20,14 @@ const List = ({ setShowForm, setPreviousAdmin }) => {
   };
 
   return (
-    <section className={styles.container}>
-      <table>
-        <thead>
-          <tr>
-            <th id="id">ID</th>
-            <th id="firstName">First Name</th>
-            <th id="lastName">Last Name</th>
-            <th id="phone">Phone</th>
-            <th id="email">Email</th>
-          </tr>
-        </thead>
-        <tbody>
-          {admins.map((item) => {
-            return (
-              <Row
-                key={item._id}
-                data={item}
-                headers={['_id', 'firstName', 'lastName', 'phone', 'email']}
-                deleteItem={() => handleDelete(item._id)}
-                editItem={() => handleEdit(item)}
-              />
-            );
-          })}
-        </tbody>
-      </table>
-    </section>
+    <Table
+      title={'Admins'}
+      data={admins}
+      headersColumns={['ID', 'Fist Name', 'Last Name', 'Phone', 'Email']}
+      headers={['_id', 'firstName', 'lastName', 'phone', 'email']}
+      deleteItem={handleDelete}
+      editItem={handleEdit}
+    />
   );
 };
 

--- a/src/Components/SuperAdmin/Admins/index.js
+++ b/src/Components/SuperAdmin/Admins/index.js
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import styles from './admins.module.css';
-import List from './List/List';
-import AdminForm from './Form/AdminForm';
-import Modal from '../../Shared/Modal/Modal';
-import Button from '../../Shared/Buttons/Buttons';
-import Loader from '../../Shared/Loader/Loader';
+import styles from 'Components/SuperAdmin/Admins/admins.module.css';
+import List from 'Components/SuperAdmin/Admins/List/List';
+import AdminForm from 'Components/SuperAdmin/Admins/Form/AdminForm';
+import Modal from 'Components/Shared/Modal/Modal';
+import Button from 'Components/Shared/Buttons/Buttons';
+import Loader from 'Components/Shared/Loader/Loader';
 import { useDispatch, useSelector } from 'react-redux';
-import { getAdmins } from '../../../redux/admins/thunks';
+import { getAdmins } from 'redux/admins/thunks';
 
 const Admins = () => {
   const dispatch = useDispatch();

--- a/src/Components/SuperAdmin/Admins/index.js
+++ b/src/Components/SuperAdmin/Admins/index.js
@@ -44,7 +44,6 @@ const Admins = () => {
         <Loader show={isLoading} />
       ) : (
         <section className={styles.container}>
-          <h2>Admins</h2>
           <AdminForm
             showForm={showForm}
             setShowForm={setShowForm}

--- a/src/redux/admins/actions.js
+++ b/src/redux/admins/actions.js
@@ -11,7 +11,7 @@ import {
   EDIT_ADMIN_PENDING,
   EDIT_ADMIN_SUCCESS,
   EDIT_ADMIN_ERROR
-} from './constants';
+} from 'redux/admins/constants';
 
 export const getAdminsPending = () => ({
   type: GET_ADMINS_PENDING

--- a/src/redux/admins/reducer.js
+++ b/src/redux/admins/reducer.js
@@ -11,7 +11,7 @@ import {
   EDIT_ADMIN_PENDING,
   EDIT_ADMIN_SUCCESS,
   EDIT_ADMIN_ERROR
-} from './constants';
+} from 'redux/admins/constants';
 
 const initialState = {
   list: [],

--- a/src/redux/admins/thunks.js
+++ b/src/redux/admins/thunks.js
@@ -75,11 +75,11 @@ export const addAdmin = (admin) => {
   };
 };
 
-export const editAdmin = (admin) => {
+export const editAdmin = (admin, _id) => {
   return async (dispatch) => {
     dispatch(editAdminPending());
     try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/admins/${admin._id}`, {
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/admins/${_id}`, {
         method: 'PUT',
         headers: {
           'Content-type': 'application/json'

--- a/src/redux/admins/thunks.js
+++ b/src/redux/admins/thunks.js
@@ -11,7 +11,7 @@ import {
   editAdminPending,
   editAdminSuccess,
   editAdminError
-} from './actions';
+} from 'redux/admins/actions';
 
 export const getAdmins = () => {
   return async (dispatch) => {


### PR DESCRIPTION
In this branch the add and edit forms were updated using the "React-Hook-Form" library. The tasks done are:

- [x]  Update the paths from relative paths to absolute paths

- [x]  Add schemas with joi

- [x]  Add validation with joi. (Work with mode: onChange)

- [x] Set input with previous data for editing

- [x]  Do a reset function for cleaning the fields


Notes: 
- The reset button for the edit form deletes the changes on the data of the admin we are editing, not all the data, as it does in the add form.
- The previous active status is not shown on the edit form. 
- The validation for the phone number does not accept spaces, as it was simplified to match the validation from the back-end.
This means it only sees the input is a number with 10 digits that can not stay empty when submiting.